### PR TITLE
Add doctors tab to hospital view

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,4 @@ crashlytics-build.properties
 
 public/assets/
 data/additional
+.DS_Store

--- a/app/controllers/admin/comparisons_controller.rb
+++ b/app/controllers/admin/comparisons_controller.rb
@@ -70,9 +70,11 @@ class Admin::ComparisonsController < Admin::AdminController
 
     # Never trust parameters from the scary internet, only allow the white list through.
     def comparison_params
-      params.require(:comparison).permit(:name, :name_de, :name_fr, :name_it, :description_de,
+      p = params.require(:comparison).permit(:name, :name_de, :name_fr, :name_it, :description_de,
                                          :description_fr, :description_it, :limit_field,
-                                         :limit_operator, :limit_value, :base_year, :rank)
+                                         :limit_operator, :limit_value, :base_year, :rank, :doctor_fields)
+      p[:doctor_fields] = p[:doctor_fields].split(',').map(&:strip) if p[:doctor_fields]
+      p
     end
 
     def set_variables

--- a/app/controllers/comparisons_controller.rb
+++ b/app/controllers/comparisons_controller.rb
@@ -2,11 +2,12 @@ class ComparisonsController < ApplicationController
   include Locatable
 
   def index
-   @comparisons = Comparison.order_by(:rank => 'asc')
+    @comparisons = Comparison.order_by(:rank => 'asc')
   end
 
   def show
     @comparison = Comparison.find(params['id'])
+    session[:last_comparison_id] = @comparison.id
     @variables = @comparison.variables
     @hospitals = @comparison.hospitals.sort_by { |h| h.distance_to @location }[0..9]
   end

--- a/app/controllers/hospitals_controller.rb
+++ b/app/controllers/hospitals_controller.rb
@@ -19,7 +19,7 @@ class HospitalsController < ApplicationController
                  Doctor.all
                end
 
-    @doctors = @doctors.geo_near(@hospital.location).max_distance(10)
+    @doctors = @doctors.geo_near(@hospital.location).max_distance(10).to_a[0..29]
   end
 
   def field

--- a/app/controllers/hospitals_controller.rb
+++ b/app/controllers/hospitals_controller.rb
@@ -6,7 +6,20 @@ class HospitalsController < ApplicationController
   # GET /admin/hospitals/1.json
   def show
     @comparisons = Comparison.order_by(:rank => 'asc')
-    @doctors = Doctor.geo_near(@hospital.location).max_distance(10).to_a[0..9]
+
+    @doctors = if session[:last_comparison_id].present?
+                 @last_comparison = Comparison.find(session[:last_comparison_id])
+
+                 if @last_comparison.doctor_fields.any?
+                   Doctor.any_in(docfields: @last_comparison.doctor_fields)
+                 else
+                   Doctor.all
+                 end
+               else
+                 Doctor.all
+               end
+
+    @doctors = @doctors.geo_near(@hospital.location).max_distance(10)
   end
 
   def field

--- a/app/controllers/hospitals_controller.rb
+++ b/app/controllers/hospitals_controller.rb
@@ -1,10 +1,12 @@
 class HospitalsController < ApplicationController
+  include Locatable
   before_action :set_hospital, only: [:show, :field]
 
   # GET /admin/hospitals/1
   # GET /admin/hospitals/1.json
   def show
     @comparisons = Comparison.order_by(:rank => 'asc')
+    @doctors = Doctor.geo_near(@hospital.location).max_distance(10).to_a[0..9]
   end
 
   def field

--- a/app/helpers/doctors_helper.rb
+++ b/app/helpers/doctors_helper.rb
@@ -1,0 +1,7 @@
+module DoctorsHelper
+
+  def doctor_address(doctor)
+    doctor.address.split(',').map(&:strip).join('<br>').html_safe
+  end
+
+end

--- a/app/models/comparison.rb
+++ b/app/models/comparison.rb
@@ -6,30 +6,30 @@ class Comparison
 
   field :name, localize: true
 
-  field :name_de, :type => String, :default => 'Name Deutsch'
-  field :name_fr, :type => String, :default => 'Nom français'
-  field :name_it, :type => String, :default => 'Nome italiano'
-  field :description_de, :type => String, :default => ''
-  field :description_fr, :type => String, :default => ''
-  field :description_it, :type => String, :default => ''
+  field :name_de, type: String, default: 'Name Deutsch'
+  field :name_fr, type: String, default: 'Nom français'
+  field :name_it, type: String, default: 'Nome italiano'
+  field :description_de, type: String, default: ''
+  field :description_fr, type: String, default: ''
+  field :description_it, type: String, default: ''
 
-  field :base_year, :type => String, :default => '2013'
+  field :base_year, type: String, default: '2013'
 
   # only hospitals that meet the following limitations are considered for this comparison
 
   # field name of the limit field
-  field :limit_field, :type => String, :default => nil
+  field :limit_field, type: String, default: nil
   # limit operator, one of '>', '<', 'exists', '='
-  field :limit_operator, :type => String, :default => '>'
+  field :limit_operator, type: String, default: '>'
   # limit value if '>', '<' or '='
-  field :limit_value, :type => String, :default => ''
+  field :limit_value, type: String, default: ''
 
   # sort comparisons according rank
-  field :rank, :type => Integer
+  field :rank, type: Integer
 
   # get all hostpials that meet the limitiations.
   def hospitals
-    var = Variable.where(:field_name => limit_field).first
+    var = Variable.where(field_name: limit_field).first
     return Hospital.all if var.nil?
     value = limit_value
     value = value.to_f if var.variable_type == :number || var.variable_type == :percentage

--- a/app/models/comparison.rb
+++ b/app/models/comparison.rb
@@ -27,6 +27,9 @@ class Comparison
   # sort comparisons according rank
   field :rank, type: Integer
 
+  # The types of doctors relevant to this comparison
+  field :doctor_fields, type: Array, default: []
+
   # get all hostpials that meet the limitiations.
   def hospitals
     var = Variable.where(field_name: limit_field).first

--- a/app/models/doctor.rb
+++ b/app/models/doctor.rb
@@ -1,0 +1,30 @@
+class Doctor
+  include Mongoid::Document
+  include Geocoder::Model::Mongoid
+
+  field :name
+  field :title
+  field :address
+  field :email
+  field :phone1
+  field :phone2
+  field :canton
+  field :docfields, type: Array, default: []
+  field :location, type: Array, default: [7.43, 46.96]
+
+  geocoded_by :address, coordinates: :location
+  reverse_geocoded_by :location
+
+  index({ location: '2d'}, { min: -200, max: 200 })
+
+  scope :with_speciality, ->(field) { where(docfields: field) }
+  scope :in_canton, ->(canton) { where(canton: canton) }
+
+  def nametitle
+    "#{title}-#{name}"
+  end
+
+  def clean_address
+    address.gsub(/\u00a0/, ' ')
+  end
+end

--- a/app/models/variable.rb
+++ b/app/models/variable.rb
@@ -10,32 +10,32 @@ class Variable
   # Corresponds to the field name
   field :field_name
   # rank is used to order variables
-  field :rank, :type => Integer, :default => 0
+  field :rank, type: Integer, default: 0
   #  import_rank is used as a column identifier in imports. 1 is the first column
-  field :import_rank, :type => Integer, :default => 0
+  field :import_rank, type: Integer, default: 0
   # all variable sets by name containing this variable
-  field :variable_sets, :type => Array, :default => []
+  field :variable_sets, type: Array, default: []
 
-  field :name_de, :type => String, :default => 'Name Deutsch'
-  field :name_fr, :type => String, :default => 'Nom français'
-  field :name_it, :type => String, :default => 'Nome italiano'
-  field :description_de, :type => String, :default => ''
-  field :description_fr, :type => String, :default => ''
-  field :description_it, :type => String, :default => ''
+  field :name_de, type: String, default: 'Name Deutsch'
+  field :name_fr, type: String, default: 'Nom français'
+  field :name_it, type: String, default: 'Nome italiano'
+  field :description_de, type: String, default: ''
+  field :description_fr, type: String, default: ''
+  field :description_it, type: String, default: ''
 
-  field :variable_type, :type => Symbol, :default => :string # can be one of :percentage, :string, :boolean, :number, :link, :relevance,
+  field :variable_type, type: Symbol, default: :string # can be one of :percentage, :string, :boolean, :number, :link, :relevance,
 
   # Is this a time series variable
-  field :is_time_series, :type => Boolean, :default => false
+  field :is_time_series, type: Boolean, default: false
 
   # possible values if enum string, null, empty => free text or numeric
-  field :values, :type => Array, :default => []
-  field :values_de, :type => Array, :default => []
-  field :values_fr, :type => Array, :default => []
-  field :values_it, :type => Array, :default => []
+  field :values, type: Array, default: []
+  field :values_de, type: Array, default: []
+  field :values_fr, type: Array, default: []
+  field :values_it, type: Array, default: []
 
   # highlight level for percentages: values above this threshold will be highlighted
-  field :highlight_threshold, :type => Float, :default => 100
+  field :highlight_threshold, type: Float, default: 100
 
   def is_enum
     return values != nil && !values.empty?

--- a/app/views/admin/comparisons/_form.html.haml
+++ b/app/views/admin/comparisons/_form.html.haml
@@ -44,6 +44,9 @@
       %td= f.label 'Sortierrang'
       %td= f.number_field :rank
     %tr
+      %td= f.label 'Arzt Fachgebiete'
+      %td= f.text_field :doctor_fields, value: @comparison.doctor_fields.join(',')
+    %tr
       %td Bedingung
       %td= f.text_field :limit_field
       %td= f.select :limit_operator, options_for_select([['>', '>'], ['<', '<'], ['=', '='], ['≠', '<>'], ['existiert', 'exists']], @comparison.limit_operator)

--- a/app/views/hospitals/_doctors.html.haml
+++ b/app/views/hospitals/_doctors.html.haml
@@ -1,10 +1,11 @@
 %ul.list-group
-
+  %li.list-group-item.list-group-item-info
+    %h4 Folgende Ärzte befinden sich in der näheren Umgebung dieses Standortes:
   - @doctors.each do |d|
     %li.list-group-item
       %p= d.title
       %p= d.name
       %p= doctor_address(d)
 
-      %p= d.phone2
-      %p= d.email
+      %p= tel_to d.phone2 unless d.phone2.blank?
+      %p= d.email unless d.email.blank?

--- a/app/views/hospitals/_doctors.html.haml
+++ b/app/views/hospitals/_doctors.html.haml
@@ -1,0 +1,10 @@
+%ul.list-group
+
+  - @doctors.each do |d|
+    %li.list-group-item
+      %p= d.title
+      %p= d.name
+      %p= doctor_address(d)
+
+      %p= d.phone2
+      %p= d.email

--- a/app/views/hospitals/_doctors.html.haml
+++ b/app/views/hospitals/_doctors.html.haml
@@ -4,8 +4,8 @@
   - @doctors.each do |d|
     %li.list-group-item
       %p= d.title
-      %p= d.name
+      %strong= d.name
       %p= doctor_address(d)
 
       %p= tel_to d.phone2 unless d.phone2.blank?
-      %p= d.email unless d.email.blank?
+      %p= mail_to(d.email, fa_icon('envelope-o', d.email), target: '_blank') unless d.email.blank?

--- a/app/views/hospitals/show.html.haml
+++ b/app/views/hospitals/show.html.haml
@@ -40,4 +40,4 @@
                   %br
                   = tel_to location.phone2
     #doctors.tab-pane.fade
-      = 'Coming Soon'
+      = render partial: 'doctors'

--- a/app/views/layouts/admin.html.haml
+++ b/app/views/layouts/admin.html.haml
@@ -24,7 +24,7 @@
           %span.icon-bar
         %a.navbar-brand(href="#{home_path}")
           %i.fa.fa-user-md
-          = t('app-title') + ' Admin'
+          = 'QM Admin'
         .navbar-collapse.collapse.navbar-responsive-collapse
           %ul.nav.navbar-nav
             %li= link_to fa_icon('wrench', 'Spitäler'), admin_hospitals_url

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -446,4 +446,29 @@ namespace :db do
     end
   end
 
+  desc 'Seed Doctors'
+  task :seed_doctors => :environment do
+    Doctor.delete_all
+
+    file = Rails.root.join 'data', 'doctor', 'doctors.csv'
+    count = `wc -l #{file}`.to_i
+
+    pg = ProgressBar.create(total: count, title: 'Seeding Doctors')
+
+    IO.foreach(file) do |line|
+      row = line.split ';'
+      speciality = row[8].strip
+
+      pg.increment
+      next if speciality == 'spital'
+
+      name, title, address, email, phone1, phone2, canton = row.values_at(1,2,3,4,5,6,7)
+      location = row.values_at(9, 10).map(&:to_f)
+
+      Doctor.create! name: name, title: title, address: address, email: email,
+                     phone1: phone1, phone2: phone2, canton: canton, location: location, docfields: speciality.split(',')
+    end
+
+  end
+
 end


### PR DESCRIPTION
This PR adds a doctor view to the hospital view. The doctors tab will display the first 30 doctors in the general vicinity of the viewed hospital's location. The doctor's speciality will be inferred from the context of the last viewed comparison. In the admin interface, it is possible to adjust what kind of doctors will appear for a specific comparison.